### PR TITLE
fix: point youtu_parsing_utils dependency to the public repo

### DIFF
--- a/youtu_hf_parser/requirements.txt
+++ b/youtu_hf_parser/requirements.txt
@@ -8,4 +8,4 @@ opencv-python-headless==4.12.0.88
 numba==0.60.0
 Pillow>=8.0.0
 tqdm
-git+https://git.tencent.com/marcowu/youtu-parsing-sdk.git#subdirectory=youtu_parsing_utils
+youtu-parsing-utils @ git+https://github.com/TencentCloudADP/youtu-parsing.git#subdirectory=youtu_parsing_utils


### PR DESCRIPTION
The requirements pin referenced an internal Tencent git host, which is unreachable for external users and breaks installs. setup.py and pyproject.toml already use the public GitHub subdirectory, so align requirements.txt with them.

Fixes #16